### PR TITLE
[ZD-009] Fix bug of treating bools as strings

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -8,14 +8,14 @@ INFO = 20
 WARNING = 30
 ERROR = 40
 # Default log Level
-FILE_LOG_LEVEL = ERROR
-LOG_LEVEL = ERROR
+FILE_LOG_LEVEL = DEBUG
+LOG_LEVEL = DEBUG
 LOG_FORMAT = '%(asctime)s - %(levelname)s - %(funcName)s - %(message)s'
 LOG_FILE = 'search_app.log'
 # Default configuration
-DEFAULT_ORG_DATA = 'assets/organizations.json'
-DEFAULT_USER_DATA = 'assets/users.json'
-DEFAULT_TICKET_DATA = 'assets/tickets.json'
+DEFAULT_ORG_DATA = 'assets/test_orgs.json'
+DEFAULT_USER_DATA = 'assets/test_users.json'
+DEFAULT_TICKET_DATA = 'assets/test_tickets.json'
 DEFAULT_RESULT_URI = 'results'
 DEFAULT_ORG_KEY_NAME = 'name'
 DEFAULT_USER_KEY_NAME = 'name'

--- a/app/search_api.py
+++ b/app/search_api.py
@@ -54,7 +54,10 @@ class SearchAPI:
       elif value == search_value:
         result = org
       elif isinstance(value, bool):
-        result = org
+        logging.debug(f"{value} is same bool equivalent as {search_value}?")
+        if str(value) == search_value:
+          logging.debug(f"yes it is")
+          result = org
       if result is not None:
         return ResultSet(org, field, search_value)
 

--- a/app/search_api.py
+++ b/app/search_api.py
@@ -93,19 +93,24 @@ class SearchAPI:
     result = None
     for user in user_dao.users:
       value = user.get(field)
+      logging.debug(f"{value} being tested now...")
       if value is None:
+        logging.debug(f"value is none, continuing...")
         # Assuming schema is flexible, so checking each user...
         continue
       elif isinstance(value, list):
         # search inside list, e.g. 'tags'
-        logging.debug(f"{field} is of list type")
+        logging.debug(f"{value} is of list type")
         for iter in value:
           if iter == search_value:
             result = user
       elif value == search_value:
         result = user
       elif isinstance(value, bool):
-        result = user
+        logging.debug(f"{value} is same bool equivalent as {search_value}?")
+        if str(value) == search_value:
+          logging.debug(f"yes it is")
+          result = user
       if result is not None:
         return ResultSet(user, field, search_value)
 
@@ -148,11 +153,15 @@ class SearchAPI:
         # search inside list, e.g. 'tags'
         logging.debug(f"{field} is of list type")
         for iter in value:
+          logging.debug(f"{field} is iter")
           if iter == search_value:
+            logging.debug(f"{field} found as {search_value}")
             result = ticket
       elif value == search_value:
+        logging.debug(f"{field} alternative as {search_value}")
         result = ticket
       elif isinstance(value, bool):
+        logging.debug(f"{field} is bolean")
         result = ticket
       if result is not None:
         return ResultSet(ticket, field, search_value)

--- a/app/search_api.py
+++ b/app/search_api.py
@@ -151,17 +151,16 @@ class SearchAPI:
         continue
       elif isinstance(value, list):
         # search inside list, e.g. 'tags'
-        logging.debug(f"{field} is of list type")
+        logging.debug(f"{value} is of list type")
         for iter in value:
-          logging.debug(f"{field} is iter")
           if iter == search_value:
-            logging.debug(f"{field} found as {search_value}")
             result = ticket
       elif value == search_value:
-        logging.debug(f"{field} alternative as {search_value}")
         result = ticket
       elif isinstance(value, bool):
-        logging.debug(f"{field} is bolean")
-        result = ticket
+        logging.debug(f"{value} is same bool equivalent as {search_value}?")
+        if str(value) == search_value:
+          logging.debug(f"yes it is")
+          result = ticket
       if result is not None:
         return ResultSet(ticket, field, search_value)

--- a/tests/app/test_search_api_users.py
+++ b/tests/app/test_search_api_users.py
@@ -87,3 +87,9 @@ def test_search_user_by_bool_field(search_data):
   user_result_set = SearchAPI.search_user_by_field(search_data.user_dao, 'suspended', 'False')
   assert isinstance(user_result_set, ResultSet)
   assert user_result_set.item['signature'] == "Don't Worry Be Happy!"
+
+def test_search_user_by_bool_field(search_data):
+  user_result_set = SearchAPI.search_user_by_field(search_data.user_dao, 'active', 'False')
+  print(user_result_set)
+  assert isinstance(user_result_set, ResultSet)
+  assert user_result_set.item['active'] == False


### PR DESCRIPTION
A bug on the interface between the chair and the screen 🤦 
I was comparing transforming the text value of "True" to Boolean when loading and validating, but when searching for a term, I was comparing the boolean value to the String input, e.g.: True == 'True' which of course is incorrect!